### PR TITLE
Fix compilation on OS X and ubuntu

### DIFF
--- a/busysteg.cpp
+++ b/busysteg.cpp
@@ -191,9 +191,9 @@ void hide_data(char* inimg, char* indata, char* outimg) {
   if ( ! fin.good() ) {
     fatalerror("Could not read data from file. Please check path.");
   }
-  long int fsize = fin.tellg();
+  char_traits<char>::pos_type fstart = fin.tellg();
   fin.seekg(0, ios_base::end);
-  fsize = fin.tellg() - fsize;
+  long int fsize = (long int) (fin.tellg() - fstart);
   fin.seekg(0, ios_base::beg);
   char *buf = new char[fsize + 16];
   memcpy(buf, "BUSYSTEG", 8);


### PR DESCRIPTION
The output of the `tellg` function is a `pos_type`. Some compilers do not like to subtract integers and `pos_type`. One can store the `pos_type` and perform the subtraction among the same type in order to obtain the int as a difference.